### PR TITLE
Missing else caused command line arguments to be ignored

### DIFF
--- a/create_model_coast.f90
+++ b/create_model_coast.f90
@@ -78,6 +78,7 @@ if(istat /= 0) attributes%creator = 'A mysterious entity'
 nargs=command_argument_count()
 if ( nargs == 0 ) then
    write(*,*) 'No arguments, all solid boundaries'
+else
 do i = 1,nargs
    call get_command_argument(i,carg)
    select case(trim(carg))


### PR DESCRIPTION
Hey Russ,

There was a missing else, which short-circuited the command line processing.

I'm using emacs which does automatic indenting. It can help a lot with spotting bugs, would it be ok once this has been merged if pushed a version with the indenting changed? 

Cheers

Aidan
